### PR TITLE
Updated document drive interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "test:watch": "vitest watch"
     },
     "peerDependencies": {
-        "document-model": "^1.0.17",
+        "document-model": "^1.0.19",
         "document-model-libs": "^1.1.26",
         "localforage": "^1.10.0"
     },
@@ -36,7 +36,7 @@
         "@typescript-eslint/eslint-plugin": "^6.12.0",
         "@typescript-eslint/parser": "^6.12.0",
         "@vitest/coverage-v8": "^0.34.6",
-        "document-model": "^1.0.18",
+        "document-model": "^1.0.19",
         "document-model-libs": "^1.1.26",
         "eslint": "^8.54.0",
         "eslint-config-prettier": "^9.0.0",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -44,11 +44,23 @@ export class DocumentDriveServer implements IDocumentDriveServer {
         return documentModel;
     }
 
-    addDrive(drive: DriveInput) {
+    async addDrive(drive: DriveInput) {
+        const id = drive.global.id;
+        if (!id) {
+            throw new Error('Invalid Drive Id');
+        }
+        try {
+            const driveStorage = await this.storage.getDrive(id);
+            if (driveStorage) {
+                throw new Error('Drive already exists');
+            }
+        } catch {
+            // ignore error has it means drive does not exist already
+        }
         const document = utils.createDocument({
             state: drive
         });
-        return this.storage.createDrive(document);
+        return this.storage.createDrive(id, document);
     }
 
     deleteDrive(id: string) {

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -31,8 +31,8 @@ export type SignalResult = {
 export type IOperationResult<T extends Document = Document> = {
     success: boolean;
     error?: Error;
-    operation: Operation;
-    document: T;
+    operations: Operation[];
+    document: T | undefined;
     signals: SignalResult[];
 };
 
@@ -56,7 +56,7 @@ export interface IDocumentDriveServer {
         drive: string,
         id: string,
         operations: Operation[]
-    ): Promise<IOperationResult[]>;
+    ): Promise<IOperationResult>;
 
     addDriveOperation(
         drive: string,
@@ -65,5 +65,5 @@ export interface IDocumentDriveServer {
     addDriveOperations(
         drive: string,
         operations: Operation<DocumentDriveAction | BaseAction>[]
-    ): Promise<IOperationResult<DocumentDriveDocument>[]>;
+    ): Promise<IOperationResult<DocumentDriveDocument>>;
 }

--- a/src/storage/browser.ts
+++ b/src/storage/browser.ts
@@ -1,5 +1,11 @@
 import { DocumentDriveAction } from 'document-model-libs/document-drive';
-import { Document, DocumentHeader, Operation } from 'document-model/document';
+import {
+    BaseAction,
+    Document,
+    DocumentHeader,
+    Operation
+} from 'document-model/document';
+import { mergeOperations } from '..';
 import { DocumentDriveStorage, DocumentStorage, IDriveStorage } from './types';
 
 export class BrowserStorage implements IDriveStorage {
@@ -58,11 +64,10 @@ export class BrowserStorage implements IDriveStorage {
             throw new Error(`Document with id ${id} not found`);
         }
 
-        const mergedOperations = operations.reduce((acc, curr) => {
-            const operations = acc[curr.scope] ?? [];
-            acc[curr.scope] = [...operations, curr];
-            return acc;
-        }, document.operations);
+        const mergedOperations = mergeOperations(
+            document.operations,
+            operations
+        );
 
         await (
             await this.db
@@ -111,18 +116,11 @@ export class BrowserStorage implements IDriveStorage {
 
     async addDriveOperations(
         id: string,
-        operations: Operation[],
+        operations: Operation<DocumentDriveAction | BaseAction>[],
         header: DocumentHeader
     ): Promise<void> {
         const drive = await this.getDrive(id);
-        const mergedOperations = operations.reduce((acc, curr) => {
-            const operations = acc[curr.scope] ?? [];
-            acc[curr.scope] = [
-                ...operations,
-                curr
-            ] as Operation<DocumentDriveAction>[];
-            return acc;
-        }, drive.operations);
+        const mergedOperations = mergeOperations(drive.operations, operations);
 
         (await this.db).setItem(this.buildKey(BrowserStorage.DRIVES_KEY, id), {
             ...drive,

--- a/src/storage/browser.ts
+++ b/src/storage/browser.ts
@@ -1,6 +1,6 @@
-import { DocumentDriveDocument } from 'document-model-libs/document-drive';
-import { Document } from 'document-model/document';
-import { IDriveStorage } from './types';
+import { DocumentDriveAction } from 'document-model-libs/document-drive';
+import { Document, DocumentHeader, Operation } from 'document-model/document';
+import { DocumentDriveStorage, DocumentStorage, IDriveStorage } from './types';
 
 export class BrowserStorage implements IDriveStorage {
     private db: Promise<LocalForage>;
@@ -39,7 +39,7 @@ export class BrowserStorage implements IDriveStorage {
         return document;
     }
 
-    async saveDocument(drive: string, id: string, document: Document) {
+    async createDocument(drive: string, id: string, document: DocumentStorage) {
         await (await this.db).setItem(this.buildKey(drive, id), document);
     }
 
@@ -47,56 +47,88 @@ export class BrowserStorage implements IDriveStorage {
         await (await this.db).removeItem(this.buildKey(drive, id));
     }
 
+    async addDocumentOperations(
+        drive: string,
+        id: string,
+        operations: Operation[],
+        header: DocumentHeader
+    ): Promise<void> {
+        const document = await this.getDocument(drive, id);
+        if (!document) {
+            throw new Error(`Document with id ${id} not found`);
+        }
+
+        const mergedOperations = operations.reduce((acc, curr) => {
+            const operations = acc[curr.scope] ?? [];
+            acc[curr.scope] = [...operations, curr];
+            return acc;
+        }, document.operations);
+
+        await (
+            await this.db
+        ).setItem(this.buildKey(drive, id), {
+            ...document,
+            ...header,
+            operations: mergedOperations
+        });
+    }
+
     async getDrives() {
-        const drives =
-            (await (
-                await this.db
-            ).getItem<DocumentDriveDocument[]>(BrowserStorage.DRIVES_KEY)) ??
-            [];
-        return drives.map(drive => drive.state.global.id);
+        const keys = (await (await this.db).keys()) ?? [];
+        return keys
+            .filter(key => key.startsWith(BrowserStorage.DRIVES_KEY))
+            .map(key =>
+                key.slice(
+                    BrowserStorage.DRIVES_KEY.length + BrowserStorage.SEP.length
+                )
+            );
     }
 
     async getDrive(id: string) {
-        const drives =
-            (await (
-                await this.db
-            ).getItem<DocumentDriveDocument[]>(BrowserStorage.DRIVES_KEY)) ??
-            [];
-        const drive = drives.find(drive => drive.state.global.id === id);
+        const drive = await (
+            await this.db
+        ).getItem<DocumentDriveStorage>(
+            this.buildKey(BrowserStorage.DRIVES_KEY, id)
+        );
         if (!drive) {
             throw new Error(`Drive with id ${id} not found`);
         }
         return drive;
     }
 
-    async saveDrive(drive: DocumentDriveDocument) {
+    async createDrive(id: string, drive: DocumentDriveStorage) {
         const db = await this.db;
-        const drives =
-            (await db.getItem<DocumentDriveDocument[]>(
-                BrowserStorage.DRIVES_KEY
-            )) ?? [];
-        const index = drives.findIndex(
-            d => d.state.global.id === drive.state.global.id
-        );
-        if (index > -1) {
-            drives[index] = drive;
-        } else {
-            drives.push(drive);
-        }
-        await db.setItem(BrowserStorage.DRIVES_KEY, drives);
+        await db.setItem(this.buildKey(BrowserStorage.DRIVES_KEY, id), drive);
     }
 
     async deleteDrive(id: string) {
         const documents = await this.getDocuments(id);
         await Promise.all(documents.map(doc => this.deleteDocument(id, doc)));
-        const db = await this.db;
-        const drives =
-            (await db.getItem<DocumentDriveDocument[]>(
-                BrowserStorage.DRIVES_KEY
-            )) ?? [];
-        await db.setItem(
-            BrowserStorage.DRIVES_KEY,
-            drives.filter(drive => drive.state.global.id !== id)
+        return (await this.db).removeItem(
+            this.buildKey(BrowserStorage.DRIVES_KEY, id)
         );
+    }
+
+    async addDriveOperations(
+        id: string,
+        operations: Operation[],
+        header: DocumentHeader
+    ): Promise<void> {
+        const drive = await this.getDrive(id);
+        const mergedOperations = operations.reduce((acc, curr) => {
+            const operations = acc[curr.scope] ?? [];
+            acc[curr.scope] = [
+                ...operations,
+                curr
+            ] as Operation<DocumentDriveAction>[];
+            return acc;
+        }, drive.operations);
+
+        (await this.db).setItem(this.buildKey(BrowserStorage.DRIVES_KEY, id), {
+            ...drive,
+            ...header,
+            operations: mergedOperations
+        });
+        return;
     }
 }

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -1,13 +1,10 @@
-import {
-    DocumentDriveAction,
-    DocumentDriveDocument
-} from 'document-model-libs/document-drive';
+import { DocumentDriveAction } from 'document-model-libs/document-drive';
 import { Document, DocumentHeader, Operation } from 'document-model/document';
-import { DocumentStorage, IDriveStorage } from './types';
+import { DocumentDriveStorage, DocumentStorage, IDriveStorage } from './types';
 
 export class MemoryStorage implements IDriveStorage {
     private documents: Record<string, Record<string, DocumentStorage>>;
-    private drives: Record<string, DocumentDriveDocument>;
+    private drives: Record<string, DocumentDriveStorage>;
 
     constructor() {
         this.documents = {};
@@ -63,10 +60,7 @@ export class MemoryStorage implements IDriveStorage {
         operations: Operation[],
         header: DocumentHeader
     ): Promise<void> {
-        if (!this.documents[drive]) {
-            throw new Error(`Drive with id ${drive} not found`);
-        }
-        const document = this.documents[drive]![id];
+        const document = await this.getDocument(drive, id);
         if (!document) {
             throw new Error(`Document with id ${id} not found`);
         }
@@ -103,8 +97,8 @@ export class MemoryStorage implements IDriveStorage {
         return drive;
     }
 
-    async createDrive(drive: DocumentDriveDocument) {
-        this.drives[drive.state.global.id] = drive;
+    async createDrive(id: string, drive: DocumentDriveStorage) {
+        this.drives[id] = drive;
     }
 
     async addDriveOperations(

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -27,7 +27,7 @@ export interface IStorage {
 export interface IDriveStorage extends IStorage {
     getDrives(): Promise<string[]>;
     getDrive(id: string): Promise<DocumentDriveStorage>;
-    createDrive(drive: DocumentDriveStorage): Promise<void>;
+    createDrive(id: string, drive: DocumentDriveStorage): Promise<void>;
     deleteDrive(id: string): Promise<void>;
     addDriveOperations(
         id: string,

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,16 +1,37 @@
 import { DocumentDriveDocument } from 'document-model-libs/document-drive';
-import { Document } from 'document-model/document';
+import { Document, DocumentHeader, Operation } from 'document-model/document';
+
+export type DocumentStorage<D extends Document = Document> = Omit<
+    D,
+    'state' | 'attachments'
+>;
+export type DocumentDriveStorage = DocumentStorage<DocumentDriveDocument>;
 
 export interface IStorage {
     getDocuments: (drive: string) => Promise<string[]>;
-    getDocument(drive: string, id: string): Promise<Document>;
-    saveDocument(drive: string, id: string, document: Document): Promise<void>;
+    getDocument(drive: string, id: string): Promise<DocumentStorage>;
+    createDocument(
+        drive: string,
+        id: string,
+        document: DocumentStorage
+    ): Promise<void>;
+    addDocumentOperations(
+        drive: string,
+        id: string,
+        operations: Operation[],
+        header: DocumentHeader
+    ): Promise<void>;
     deleteDocument(drive: string, id: string): Promise<void>;
 }
 
 export interface IDriveStorage extends IStorage {
     getDrives(): Promise<string[]>;
-    getDrive(id: string): Promise<DocumentDriveDocument>;
-    saveDrive(drive: DocumentDriveDocument): Promise<void>;
+    getDrive(id: string): Promise<DocumentDriveStorage>;
+    createDrive(drive: DocumentDriveStorage): Promise<void>;
     deleteDrive(id: string): Promise<void>;
+    addDriveOperations(
+        id: string,
+        operations: Operation[],
+        header: DocumentHeader
+    ): Promise<void>;
 }

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,5 +1,13 @@
-import { DocumentDriveDocument } from 'document-model-libs/document-drive';
-import { Document, DocumentHeader, Operation } from 'document-model/document';
+import type {
+    DocumentDriveAction,
+    DocumentDriveDocument
+} from 'document-model-libs/document-drive';
+import type {
+    BaseAction,
+    Document,
+    DocumentHeader,
+    Operation
+} from 'document-model/document';
 
 export type DocumentStorage<D extends Document = Document> = Omit<
     D,
@@ -31,7 +39,7 @@ export interface IDriveStorage extends IStorage {
     deleteDrive(id: string): Promise<void>;
     addDriveOperations(
         id: string,
-        operations: Operation[],
+        operations: Operation<DocumentDriveAction | BaseAction>[],
         header: DocumentHeader
     ): Promise<void>;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,13 @@ import {
     documentModel as DocumentDriveModel,
     z
 } from 'document-model-libs/document-drive';
-import { Document } from 'document-model/document';
+import {
+    Action,
+    BaseAction,
+    Document,
+    DocumentOperations,
+    Operation
+} from 'document-model/document';
 
 export function isDocumentDrive(
     document: Document
@@ -12,4 +18,15 @@ export function isDocumentDrive(
         document.documentType === DocumentDriveModel.id &&
         z.DocumentDriveStateSchema().safeParse(document.state.global).success
     );
+}
+
+export function mergeOperations<A extends Action = Action>(
+    currentOperations: DocumentOperations<A>,
+    newOperations: Operation<A | BaseAction>[]
+): DocumentOperations<A> {
+    return newOperations.reduce((acc, curr) => {
+        const operations = acc[curr.scope] ?? [];
+        acc[curr.scope] = [...operations, curr] as Operation<A>[];
+        return acc;
+    }, currentOperations);
 }

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -13,11 +13,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { afterEach, describe, it } from 'vitest';
 import { DocumentDriveServer } from '../src/server';
-import {
-    BrowserStorage,
-    FilesystemStorage,
-    MemoryStorage
-} from '../src/storage';
+import { MemoryStorage } from '../src/storage';
 
 const documentModels = [
     DocumentModelLib,
@@ -27,9 +23,9 @@ const documentModels = [
 const FileStorageDir = path.join(__dirname, './file-storage');
 
 const storageLayers = [
-    ['MemoryStorage', () => new MemoryStorage()],
-    ['FilesystemStorage', () => new FilesystemStorage(FileStorageDir)],
-    ['BrowserStorage', () => new BrowserStorage()]
+    ['MemoryStorage', () => new MemoryStorage()]
+    // ['FilesystemStorage', () => new FilesystemStorage(FileStorageDir)],
+    // ['BrowserStorage', () => new BrowserStorage()]
 ] as const;
 
 describe.each(storageLayers)(
@@ -112,9 +108,8 @@ describe.each(storageLayers)(
                 '1',
                 operation
             );
-
             expect(drive.state.global).toStrictEqual(
-                operationResult.document.state.global
+                operationResult.document?.state.global
             );
             expect(drive.state.global.nodes).toStrictEqual([
                 {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -13,7 +13,7 @@ import fs from 'fs/promises';
 import path from 'path';
 import { afterEach, describe, it } from 'vitest';
 import { DocumentDriveServer } from '../src/server';
-import { MemoryStorage } from '../src/storage';
+import { BrowserStorage, MemoryStorage } from '../src/storage';
 
 const documentModels = [
     DocumentModelLib,
@@ -23,9 +23,9 @@ const documentModels = [
 const FileStorageDir = path.join(__dirname, './file-storage');
 
 const storageLayers = [
-    ['MemoryStorage', () => new MemoryStorage()]
+    ['MemoryStorage', () => new MemoryStorage()],
     // ['FilesystemStorage', () => new FilesystemStorage(FileStorageDir)],
-    // ['BrowserStorage', () => new BrowserStorage()]
+    ['BrowserStorage', () => new BrowserStorage()]
 ] as const;
 
 describe.each(storageLayers)(

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -13,7 +13,11 @@ import fs from 'fs/promises';
 import path from 'path';
 import { afterEach, describe, it } from 'vitest';
 import { DocumentDriveServer } from '../src/server';
-import { BrowserStorage, MemoryStorage } from '../src/storage';
+import {
+    BrowserStorage,
+    FilesystemStorage,
+    MemoryStorage
+} from '../src/storage';
 
 const documentModels = [
     DocumentModelLib,
@@ -24,7 +28,7 @@ const FileStorageDir = path.join(__dirname, './file-storage');
 
 const storageLayers = [
     ['MemoryStorage', () => new MemoryStorage()],
-    // ['FilesystemStorage', () => new FilesystemStorage(FileStorageDir)],
+    ['FilesystemStorage', () => new FilesystemStorage(FileStorageDir)],
     ['BrowserStorage', () => new BrowserStorage()]
 ] as const;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -689,10 +689,10 @@ document-model-libs@^1.1.26:
   resolved "https://registry.yarnpkg.com/document-model-libs/-/document-model-libs-1.1.26.tgz#eeb498c7c955baf0a3e01189f0701528e2e53e45"
   integrity sha512-QMjUhiQVcRfLQjjfcHEmL6rFnhJCfuzdsLrfZo9y4J6zQH705OooN454+a8XK3ZhZoV8KJ8gAMux8RAL0tWrag==
 
-document-model@^1.0.18:
-  version "1.0.18"
-  resolved "https://registry.yarnpkg.com/document-model/-/document-model-1.0.18.tgz#9b0fe34cd2d7bf9ecb9a93fbe1d8bebea79a80d9"
-  integrity sha512-JP8XMn9FYflFR85tBQ0hWsSRD2S6vnUw5MMGlshaIbBN+RYhwPWaGOWgM/LHkKdIco0nYKAhXJwJ6aTDzp6b9g==
+document-model@^1.0.19:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/document-model/-/document-model-1.0.19.tgz#064ffbbc3635cfd2257ff0d8cdea810df2285ce2"
+  integrity sha512-LchmMlJLtds2/E5BRHWZVxd5inFCcrYMmZpFFU1K51pS6FbTVqJpA/7EjmpIDQnFAyph2iVd2dSAXGv2ZepmvQ==
   dependencies:
     immer "^10.0.2"
     json-stringify-deterministic "^1.0.10"


### PR DESCRIPTION
Fixes #13.
Changed `saveDocument` to `addDocumentOperations` and `createDocument` and `saveDrive` to `addDriveOperation` and `createDrive`.

Only updated `MemoryStorage` for now