### PR TITLE
feat: added support for update noop operations

### DIFF
--- a/src/storage/browser.ts
+++ b/src/storage/browser.ts
@@ -5,7 +5,7 @@ import {
     DocumentHeader,
     Operation
 } from 'document-model/document';
-import { mergeOperations } from '..';
+import { applyUpdatedOperations, mergeOperations } from '..';
 import { DocumentDriveStorage, DocumentStorage, IDriveStorage } from './types';
 
 export class BrowserStorage implements IDriveStorage {
@@ -57,7 +57,8 @@ export class BrowserStorage implements IDriveStorage {
         drive: string,
         id: string,
         operations: Operation[],
-        header: DocumentHeader
+        header: DocumentHeader,
+        updatedOperations: Operation[] = []
     ): Promise<void> {
         const document = await this.getDocument(drive, id);
         if (!document) {
@@ -69,12 +70,17 @@ export class BrowserStorage implements IDriveStorage {
             operations
         );
 
+        const mergedUpdatedOperations = applyUpdatedOperations(
+            mergedOperations,
+            updatedOperations
+        );
+
         await (
             await this.db
         ).setItem(this.buildKey(drive, id), {
             ...document,
             ...header,
-            operations: mergedOperations
+            operations: mergedUpdatedOperations
         });
     }
 

--- a/src/storage/filesystem.ts
+++ b/src/storage/filesystem.ts
@@ -12,7 +12,7 @@ import fs from 'fs/promises';
 import stringify from 'json-stringify-deterministic';
 import path from 'path';
 import sanitize from 'sanitize-filename';
-import { mergeOperations } from '..';
+import { applyUpdatedOperations, mergeOperations } from '..';
 import { DocumentDriveStorage, DocumentStorage, IDriveStorage } from './types';
 
 type FSError = {
@@ -104,7 +104,8 @@ export class FilesystemStorage implements IDriveStorage {
         drive: string,
         id: string,
         operations: Operation[],
-        header: DocumentHeader
+        header: DocumentHeader,
+        updatedOperations: Operation[] = []
     ) {
         const document = await this.getDocument(drive, id);
         if (!document) {
@@ -116,10 +117,15 @@ export class FilesystemStorage implements IDriveStorage {
             operations
         );
 
+        const mergedUpdatedOperations = applyUpdatedOperations(
+            mergedOperations,
+            updatedOperations
+        );
+
         this.createDocument(drive, id, {
             ...document,
             ...header,
-            operations: mergedOperations
+            operations: mergedUpdatedOperations
         });
     }
 

--- a/src/storage/memory.ts
+++ b/src/storage/memory.ts
@@ -5,7 +5,7 @@ import {
     DocumentHeader,
     Operation
 } from 'document-model/document';
-import { mergeOperations } from '..';
+import { applyUpdatedOperations, mergeOperations } from '..';
 import { DocumentDriveStorage, DocumentStorage, IDriveStorage } from './types';
 
 export class MemoryStorage implements IDriveStorage {
@@ -67,7 +67,8 @@ export class MemoryStorage implements IDriveStorage {
         drive: string,
         id: string,
         operations: Operation[],
-        header: DocumentHeader
+        header: DocumentHeader,
+        updatedOperations: Operation[] = []
     ): Promise<void> {
         const document = await this.getDocument(drive, id);
         if (!document) {
@@ -79,10 +80,15 @@ export class MemoryStorage implements IDriveStorage {
             operations
         );
 
+        const mergedUpdatedOperations = applyUpdatedOperations(
+            mergedOperations,
+            updatedOperations
+        );
+
         this.documents[drive]![id] = {
             ...document,
             ...header,
-            operations: mergedOperations
+            operations: mergedUpdatedOperations
         };
     }
 

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -27,7 +27,8 @@ export interface IStorage {
         drive: string,
         id: string,
         operations: Operation[],
-        header: DocumentHeader
+        header: DocumentHeader,
+        updatedOperations?: Operation[]
     ): Promise<void>;
     deleteDocument(drive: string, id: string): Promise<void>;
 }

--- a/test/document-operations.test.ts
+++ b/test/document-operations.test.ts
@@ -2,12 +2,14 @@ import * as DocumentDrive from 'document-model-libs/document-drive';
 import * as DocumentModelsLibs from 'document-model-libs/document-models';
 import {
     Action,
+    BaseAction,
     Document,
     DocumentModel,
     Operation,
     Reducer
 } from 'document-model/document';
 import {
+    DocumentModelAction,
     DocumentModelDocument,
     module as DocumentModelLib,
     actions,
@@ -90,130 +92,226 @@ describe('Document operations', () => {
         return server.getDocument('1', '1') as Promise<DocumentModelDocument>;
     }
 
-    it('should be able to apply an operation to a document in the drive', async () => {
-        let document = await buildFile();
+    describe('Operations', () => {
+        it('should be able to apply an operation to a document in the drive', async () => {
+            let document = await buildFile();
 
-        const result = await server.addOperation(
-            '1',
-            '1',
-            buildOperation(
-                reducer,
-                document,
-                actions.setModelName({ name: 'test' })
-            )
-        );
-        expect(result.status).toBe('SUCCESS');
+            const result = await server.addOperation(
+                '1',
+                '1',
+                buildOperation(
+                    reducer,
+                    document,
+                    actions.setModelName({ name: 'test' })
+                )
+            );
+            expect(result.status).toBe('SUCCESS');
 
-        document = (await server.getDocument(
-            '1',
-            '1'
-        )) as DocumentModelDocument;
-        expect(document.state.global.name).toBe('test');
-    });
-
-    it('should reject invalid operation', async () => {
-        const document = await buildFile();
-
-        const result = await server.addOperation('1', '1', {
-            ...buildOperation(
-                reducer,
-                document,
-                actions.setStateSchema({
-                    schema: 'test',
-                    scope: 'global'
-                })
-            ),
-            input: { schema: 'test', scope: 'invalid' }
+            document = (await server.getDocument(
+                '1',
+                '1'
+            )) as DocumentModelDocument;
+            expect(document.state.global.name).toBe('test');
         });
-        expect(result.status).toBe('ERROR');
-        expect(result.error?.message).toBe('Invalid scope: invalid');
+
+        it('should reject invalid operation', async () => {
+            const document = await buildFile();
+
+            const result = await server.addOperation('1', '1', {
+                ...buildOperation(
+                    reducer,
+                    document,
+                    actions.setStateSchema({
+                        schema: 'test',
+                        scope: 'global'
+                    })
+                ),
+                input: { schema: 'test', scope: 'invalid' }
+            });
+            expect(result.status).toBe('ERROR');
+            expect(result.error?.message).toBe('Invalid scope: invalid');
+        });
+
+        it('should reject operation with existing index', async () => {
+            const document = await buildFile();
+
+            const result = await server.addOperations('1', '1', [
+                buildOperation(
+                    reducer,
+                    document,
+                    actions.setModelName({
+                        name: 'test'
+                    })
+                ),
+                buildOperation(
+                    reducer,
+                    document,
+                    actions.setModelName({
+                        name: 'test 2'
+                    }),
+                    0
+                )
+            ]);
+            expect(result.status).toBe('CONFLICT');
+            expect(result.error?.message).toBe(
+                'Conflicting operation on index 0'
+            );
+        });
+
+        it('should reject operation with missing index', async () => {
+            const document = await buildFile();
+
+            const result = await server.addOperations('1', '1', [
+                buildOperation(
+                    reducer,
+                    document,
+                    actions.setModelName({
+                        name: 'test'
+                    })
+                ),
+                buildOperation(
+                    reducer,
+                    document,
+                    actions.setModelName({
+                        name: 'test 2'
+                    }),
+                    2
+                )
+            ]);
+            expect(result.status).toBe('MISSING');
+            expect(result.error?.message).toBe('Missing operation on index 1');
+        });
+
+        it('should accept operations until invalid operation', async () => {
+            let document = await buildFile();
+
+            const result = await server.addOperations('1', '1', [
+                ...buildOperations(reducer, document, [
+                    actions.setModelName({
+                        name: 'test'
+                    }),
+                    actions.setAuthorName({
+                        authorName: 'test'
+                    }),
+                    actions.setAuthorWebsite({
+                        authorWebsite: 'www'
+                    })
+                ]),
+                buildOperation(
+                    reducer,
+                    document,
+                    actions.setModelName({
+                        name: 'test 2'
+                    }),
+                    2
+                )
+            ]);
+
+            expect(result.status).toBe('CONFLICT');
+            expect(result.operations.length).toBe(3);
+
+            document = (await server.getDocument(
+                '1',
+                '1'
+            )) as DocumentModelDocument;
+            expect(document.state.global).toEqual(
+                expect.objectContaining({
+                    name: 'test',
+                    author: { name: 'test', website: 'www' }
+                })
+            );
+        });
     });
 
-    it('should reject operation with existing index', async () => {
-        const document = await buildFile();
+    describe('skip operations', () => {
+        async function getDocumentWithOps(
+            newActions: (DocumentModelAction | BaseAction)[] = []
+        ) {
+            let document = await buildFile();
 
-        const result = await server.addOperations('1', '1', [
-            buildOperation(
-                reducer,
-                document,
-                actions.setModelName({
-                    name: 'test'
-                })
-            ),
-            buildOperation(
-                reducer,
-                document,
-                actions.setModelName({
-                    name: 'test 2'
-                }),
-                0
-            )
-        ]);
-        expect(result.status).toBe('CONFLICT');
-        expect(result.error?.message).toBe('Conflicting operation on index 0');
-    });
+            const testActions = [
+                actions.setModelName({ name: 'test' }),
+                actions.setName('test'),
+                actions.setModelId({ id: 'testId' }),
+                actions.setModelDescription({ description: 'testDescription' }),
+                actions.setModelExtension({ extension: 'testExtension' }),
+                ...newActions
+            ];
 
-    it('should reject operation with missing index', async () => {
-        const document = await buildFile();
+            for (const action of testActions) {
+                document = (await server.getDocument(
+                    '1',
+                    '1'
+                )) as DocumentModelDocument;
 
-        const result = await server.addOperations('1', '1', [
-            buildOperation(
-                reducer,
-                document,
-                actions.setModelName({
-                    name: 'test'
-                })
-            ),
-            buildOperation(
-                reducer,
-                document,
-                actions.setModelName({
-                    name: 'test 2'
-                }),
-                2
-            )
-        ]);
-        expect(result.status).toBe('MISSING');
-        expect(result.error?.message).toBe('Missing operation on index 1');
-    });
+                const op = buildOperation(reducer, document, action);
+                await server.addOperation('1', '1', op);
+            }
 
-    it('should accept operations until invalid operation', async () => {
-        let document = await buildFile();
+            document = (await server.getDocument(
+                '1',
+                '1'
+            )) as DocumentModelDocument;
 
-        const result = await server.addOperations('1', '1', [
-            ...buildOperations(reducer, document, [
-                actions.setModelName({
-                    name: 'test'
-                }),
-                actions.setAuthorName({
-                    authorName: 'test'
-                }),
-                actions.setAuthorWebsite({
-                    authorWebsite: 'www'
-                })
-            ]),
-            buildOperation(
-                reducer,
-                document,
-                actions.setModelName({
-                    name: 'test 2'
-                }),
-                2
-            )
-        ]);
+            return document;
+        }
 
-        expect(result.status).toBe('CONFLICT');
-        expect(result.operations.length).toBe(3);
+        it('should undo latest operation', async () => {
+            const undoAction = [actions.undo()];
+            const document = await getDocumentWithOps(undoAction);
 
-        document = (await server.getDocument(
-            '1',
-            '1'
-        )) as DocumentModelDocument;
-        expect(document.state.global).toEqual(
-            expect.objectContaining({
+            const expectedState = {
                 name: 'test',
-                author: { name: 'test', website: 'www' }
-            })
-        );
+                id: 'testId',
+                description: 'testDescription',
+                extension: ''
+            };
+
+            expect(document.state.global).toMatchObject(expectedState);
+            expect(document.revision.global).toBe(6);
+            expect(document.operations.global.length).toBe(6);
+            expect(document.operations.global[5]?.index).toBe(5);
+            expect(document.operations.global[5]?.skip).toBe(1);
+        });
+
+        it('should update latest undo operation', async () => {
+            const undoActions = [actions.undo(), actions.undo()];
+            const document = await getDocumentWithOps(undoActions);
+
+            const expectedState = {
+                name: 'test',
+                id: 'testId',
+                description: '',
+                extension: ''
+            };
+
+            expect(document.state.global).toMatchObject(expectedState);
+            expect(document.revision.global).toBe(6);
+            expect(document.operations.global.length).toBe(6);
+            expect(document.operations.global[5]?.index).toBe(5);
+            expect(document.operations.global[5]?.skip).toBe(2);
+        });
+
+        it('should update latest undo operation with skip = 3', async () => {
+            const undoActions = [
+                actions.undo(),
+                actions.undo(),
+                actions.undo()
+            ];
+            const document = await getDocumentWithOps(undoActions);
+
+            const expectedState = {
+                name: 'test',
+                id: '',
+                description: '',
+                extension: ''
+            };
+
+            expect(document.state.global).toMatchObject(expectedState);
+            expect(document.revision.global).toBe(6);
+            expect(document.operations.global.length).toBe(6);
+            expect(document.operations.global[5]?.index).toBe(5);
+            expect(document.operations.global[5]?.skip).toBe(3);
+        });
     });
 });

--- a/test/document-operations.test.ts
+++ b/test/document-operations.test.ts
@@ -313,5 +313,29 @@ describe('Document operations', () => {
             expect(document.operations.global[5]?.index).toBe(5);
             expect(document.operations.global[5]?.skip).toBe(3);
         });
+
+        it('should not update latest operation when latest op !== NOOP with skip', async () => {
+            const undoActions = [
+                actions.undo(),
+                actions.setModelDescription({
+                    description: 'testDescription2'
+                }),
+                actions.undo()
+            ];
+            const document = await getDocumentWithOps(undoActions);
+
+            const expectedState = {
+                name: 'test',
+                id: 'testId',
+                description: 'testDescription',
+                extension: ''
+            };
+
+            expect(document.state.global).toMatchObject(expectedState);
+            expect(document.revision.global).toBe(8);
+            expect(document.operations.global.length).toBe(8);
+            expect(document.operations.global[7]?.index).toBe(7);
+            expect(document.operations.global[7]?.skip).toBe(1);
+        });
     });
 });


### PR DESCRIPTION
## Description:

When 2 or more UNDO operations are dispatched in a row, new NOOP operations are not considered as "new operations", instead they are considered as "update" operations (index value is not increase, but skip value is updated)

This PR adds support for that scenario. When a operation is detected as an update of a previous NOOP, the new operation is handled as an update of the latest NOOP

> NOTE: This PR requires https://github.com/powerhouse-inc/document-model/pull/30