### PR TITLE
Sync status improvements

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -138,9 +138,9 @@ export class DocumentDriveServer extends BaseDocumentDriveServer {
 
             if (!driveTriggers) {
                 driveTriggers = new Map();
-                this.updateSyncStatus(driveId, 'SYNCING');
             }
 
+            this.updateSyncStatus(driveId, 'SYNCING');
             if (PullResponderTransmitter.isPullResponderTrigger(trigger)) {
                 const intervalId = PullResponderTransmitter.setupPull(
                     driveId,
@@ -786,7 +786,13 @@ export class DocumentDriveServer extends BaseDocumentDriveServer {
                         syncUnit.syncId,
                         syncUnit.revision,
                         syncUnit.lastUpdated,
+                        () => this.updateSyncStatus(drive, 'SYNCING'),
                         this.handleListenerError.bind(this)
+                    )
+                    .then(
+                        updates =>
+                            updates.length &&
+                            this.updateSyncStatus(drive, 'SUCCESS')
                     )
                     .catch(error => {
                         console.error(
@@ -917,7 +923,13 @@ export class DocumentDriveServer extends BaseDocumentDriveServer {
                         '0',
                         lastOperation.index,
                         lastOperation.timestamp,
+                        () => this.updateSyncStatus(drive, 'SYNCING'),
                         this.handleListenerError.bind(this)
+                    )
+                    .then(
+                        updates =>
+                            updates.length &&
+                            this.updateSyncStatus(drive, 'SUCCESS')
                     )
                     .catch(error => {
                         console.error(

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -93,6 +93,11 @@ export type ListenerRevision = {
     revision: number;
 };
 
+export type ListenerUpdate = {
+    listenerId: string;
+    listenerRevisions: ListenerRevision[];
+};
+
 export type UpdateStatus = 'SUCCESS' | 'CONFLICT' | 'MISSING' | 'ERROR';
 export type ErrorStatus = Exclude<UpdateStatus, 'SUCCESS'>;
 
@@ -233,8 +238,14 @@ export abstract class BaseListenerManager {
         driveId: string,
         syncId: string,
         syncRev: number,
-        lastUpdated: string
-    ): Promise<void>;
+        lastUpdated: string,
+        willUpdate?: (listeners: Listener[]) => void,
+        onError?: (
+            error: Error,
+            driveId: string,
+            listener: ListenerState
+        ) => void
+    ): Promise<ListenerUpdate[]>;
 
     abstract updateListenerRevision(
         listenerId: string,


### PR DESCRIPTION
Execute strands pull before starting pull loop.
Change sync status when transmitting to listeners.